### PR TITLE
Renamed SafeMode to SafePrompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.04 - 2024-01
+
+- Renamed parameter `SafeMode` as `SafePrompt` - [Mistral REST API was throwing a 422 since it has been made stricter](https://discord.com/channels/1144547040454508606/1184444810279522374/1195108690353717369)
+
 ## 1.0.3 - 
 
 - Replaced instances of List<> with IEnumerable<> for performance.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ var chatRequest = new ChatRequest()
     
     //  Default: false
     // Whether to inject a safety prompt before all conversations.
-    SafeMode = false,
+    SafePrompt = false,
     
     //  Default: null
     // The seed to use for random sampling. If set, different calls will generate deterministic results.

--- a/src/Models/ChatRequest.cs
+++ b/src/Models/ChatRequest.cs
@@ -23,8 +23,8 @@ namespace MistralSharp.Models
         [JsonPropertyName("stream")]
         public bool Stream { get; set; } = false;
     
-        [JsonPropertyName("safe_mode")]
-        public bool SafeMode { get; set; } = false;
+        [JsonPropertyName("safe_prompt")]
+        public bool SafePrompt { get; set; } = false;
     
         [JsonPropertyName("random_seed")]
         public int? RandomSeed { get; set; } = null;


### PR DESCRIPTION
Mistral REST API has been made stricter and now rejects extra/unknown parameters, which causes ChatRequest calls to fails as they are done with a `SafeMode` parameter, but API expects a `SafePrompt` one. There was a typo in the original Mistral documentation.

Read here: https://discord.com/channels/1144547040454508606/1184444810279522374/1195108690353717369

This change fixes the API call and we are no longer getting a `422 Unprocessable Entity`.